### PR TITLE
fix(rum): do not log URL parameters to RUM

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -47,7 +47,7 @@ export function sampleRUM(checkpoint, data = {}) {
         path: () => window.location.pathname,
       };
       // eslint-disable-next-line object-curly-newline, max-len
-      window.hlx.rum = { weight, id, random, isSelected, sampleRUM, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'full'] };
+      window.hlx.rum = { weight, id, random, isSelected, sampleRUM, sanitizeURL: urlSanitizers[window.hlx.RUM_MASK_URL || 'path'] };
     }
     const { weight, id } = window.hlx.rum;
     if (window.hlx && window.hlx.rum && window.hlx.rum.isSelected) {


### PR DESCRIPTION
BREAKING CHANGE: the default behavior of RUM collection is now to omit URL parameters. To restore the old behavior set `window.hlx.RUM_MASK_URL = 'full'`

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.hlx.page/
- After: https://<branch>--{repo}--{owner}.hlx.page/
